### PR TITLE
rspec and aws-sdk-core have changed!

### DIFF
--- a/dumbwaiter.gemspec
+++ b/dumbwaiter.gemspec
@@ -25,5 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "gem-release"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec-its"
+  spec.add_development_dependency "rspec-collection_matchers"
   spec.add_development_dependency "faker"
 end

--- a/lib/dumbwaiter/app.rb
+++ b/lib/dumbwaiter/app.rb
@@ -5,23 +5,23 @@ class Dumbwaiter::App
 
   attr_reader :stack, :opsworks_app, :opsworks
 
-  def self.all(stack, opsworks = Aws::OpsWorks.new(region: "us-east-1"))
+  def self.all(stack, opsworks = Aws::OpsWorks::Client.new(region: "us-east-1"))
     opsworks.describe_apps(stack_id: stack.id).apps.map { |app| new(stack, app, opsworks) }
   end
 
-  def self.find(stack, app_name, opsworks = Aws::OpsWorks.new(region: "us-east-1"))
+  def self.find(stack, app_name, opsworks = Aws::OpsWorks::Client.new(region: "us-east-1"))
     app = all(stack, opsworks).detect { |app| app.name == app_name }
     raise NotFound.new("No app found with name #{app_name}") if app.nil?
     app
   end
 
-  def self.find_by_id(stack, app_id, opsworks = Aws::OpsWorks.new(region: "us-east-1"))
+  def self.find_by_id(stack, app_id, opsworks = Aws::OpsWorks::Client.new(region: "us-east-1"))
     app = all(stack, opsworks).detect { |app| app.id == app_id }
     raise NotFound.new("No app found with id #{app_id}") if app.nil?
     app
   end
 
-  def initialize(stack, opsworks_app, opsworks = Aws::OpsWorks.new(region: "us-east-1"))
+  def initialize(stack, opsworks_app, opsworks = Aws::OpsWorks::Client.new(region: "us-east-1"))
     @stack = stack
     @opsworks_app = opsworks_app
     @opsworks = opsworks

--- a/lib/dumbwaiter/deployment.rb
+++ b/lib/dumbwaiter/deployment.rb
@@ -4,11 +4,11 @@ require "dumbwaiter/user_profile"
 class Dumbwaiter::Deployment
   attr_reader :stack, :opsworks_deployment, :opsworks
 
-  def self.all(stack, opsworks = Aws::OpsWorks.new(region: "us-east-1"))
+  def self.all(stack, opsworks = Aws::OpsWorks::Client.new(region: "us-east-1"))
     opsworks.describe_deployments(stack_id: stack.id).deployments.map { |d| new(stack, d, opsworks) }
   end
 
-  def initialize(stack, opsworks_deployment, opsworks = Aws::OpsWorks.new(region: "us-east-1"))
+  def initialize(stack, opsworks_deployment, opsworks = Aws::OpsWorks::Client.new(region: "us-east-1"))
     @stack = stack
     @opsworks_deployment = opsworks_deployment
     @opsworks = opsworks

--- a/lib/dumbwaiter/instance.rb
+++ b/lib/dumbwaiter/instance.rb
@@ -1,12 +1,12 @@
 class Dumbwaiter::Instance
   attr_reader :layer, :opsworks_instance, :opsworks
 
-  def self.all(layer, opsworks = Aws::OpsWorks.new(region: "us-east-1"))
+  def self.all(layer, opsworks = Aws::OpsWorks::Client.new(region: "us-east-1"))
     instances = opsworks.describe_instances(layer_id: layer.id).instances
     instances.map { |instance| new(layer, instance, opsworks) }
   end
 
-  def initialize(layer, opsworks_instance, opsworks = Aws::OpsWorks.new(region: "us-east-1"))
+  def initialize(layer, opsworks_instance, opsworks = Aws::OpsWorks::Client.new(region: "us-east-1"))
     @layer = layer
     @opsworks_instance = opsworks_instance
     @opsworks = opsworks

--- a/lib/dumbwaiter/layer.rb
+++ b/lib/dumbwaiter/layer.rb
@@ -5,17 +5,17 @@ class Dumbwaiter::Layer
 
   class NotFound < Exception; end
 
-  def self.all(stack, opsworks = Aws::OpsWorks.new(region: "us-east-1"))
+  def self.all(stack, opsworks = Aws::OpsWorks::Client.new(region: "us-east-1"))
     opsworks.describe_layers(stack_id: stack.id).layers.map { |layer| new(stack, layer, opsworks) }
   end
 
-  def self.find(stack, layer_name, opsworks = Aws::OpsWorks.new(region: "us-east-1"))
+  def self.find(stack, layer_name, opsworks = Aws::OpsWorks::Client.new(region: "us-east-1"))
     layer = all(stack, opsworks).detect { |layer| layer.shortname == layer_name }
     raise NotFound.new("No layer found with name #{layer_name}") if layer.nil?
     layer
   end
 
-  def initialize(stack, opsworks_layer, opsworks = Aws::OpsWorks.new(region: "us-east-1"))
+  def initialize(stack, opsworks_layer, opsworks = Aws::OpsWorks::Client.new(region: "us-east-1"))
     @stack = stack
     @opsworks_layer = opsworks_layer
     @opsworks = opsworks

--- a/lib/dumbwaiter/stack.rb
+++ b/lib/dumbwaiter/stack.rb
@@ -7,23 +7,23 @@ class Dumbwaiter::Stack
 
   class NotFound < Exception; end
 
-  def self.all(opsworks = Aws::OpsWorks.new(region: "us-east-1"))
+  def self.all(opsworks = Aws::OpsWorks::Client.new(region: "us-east-1"))
     opsworks.describe_stacks.stacks.map { |stack| new(stack, opsworks) }
   end
 
-  def self.find(stack_name, opsworks = Aws::OpsWorks.new(region: "us-east-1"))
+  def self.find(stack_name, opsworks = Aws::OpsWorks::Client.new(region: "us-east-1"))
     stack = all(opsworks).detect { |stack| stack.name == stack_name }
     raise NotFound.new("No stack found with name #{stack_name}") if stack.nil?
     stack
   end
 
-  def self.find_by_id(stack_id, opsworks = Aws::OpsWorks.new(region: "us-east-1"))
+  def self.find_by_id(stack_id, opsworks = Aws::OpsWorks::Client.new(region: "us-east-1"))
     stack = all(opsworks).detect { |stack| stack.id == stack_id }
     raise NotFound.new("No stack found with id #{stack_id}") if stack.nil?
     stack
   end
 
-  def initialize(opsworks_stack, opsworks = Aws::OpsWorks.new(region: "us-east-1"))
+  def initialize(opsworks_stack, opsworks = Aws::OpsWorks::Client.new(region: "us-east-1"))
     @opsworks = opsworks
     @opsworks_stack = opsworks_stack
   end

--- a/lib/dumbwaiter/user_profile.rb
+++ b/lib/dumbwaiter/user_profile.rb
@@ -5,7 +5,7 @@ class Dumbwaiter::UserProfile
     @cache ||= {}
   end
 
-  def self.find(iam_user_arn, opsworks = Aws::OpsWorks.new(region: "us-east-1"))
+  def self.find(iam_user_arn, opsworks = Aws::OpsWorks::Client.new(region: "us-east-1"))
     return nil if iam_user_arn.nil?
     unless cache.has_key?(iam_user_arn)
       cache[iam_user_arn] = opsworks.describe_user_profiles(iam_user_arns: [iam_user_arn]).user_profiles.detect { |p| p.iam_user_arn == iam_user_arn }
@@ -13,7 +13,7 @@ class Dumbwaiter::UserProfile
     cache[iam_user_arn]
   end
 
-  def initialize(opsworks_user_profile, opsworks = Aws::OpsWorks.new(region: "us-east-1"))
+  def initialize(opsworks_user_profile, opsworks = Aws::OpsWorks::Client.new(region: "us-east-1"))
     @opsworks_user_profile = opsworks_user_profile
     @opsworks = opsworks
   end

--- a/spec/lib/dumbwaiter/cli_spec.rb
+++ b/spec/lib/dumbwaiter/cli_spec.rb
@@ -8,7 +8,7 @@ describe Dumbwaiter::Cli do
 
   subject(:cli) { Dumbwaiter::Cli.new }
 
-  before { Aws::OpsWorks.stub(new: fake_opsworks) }
+  before { Aws::OpsWorks::Client.stub(new: fake_opsworks) }
 
   describe "#deploy" do
     context "when the stack exists" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,8 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require "dumbwaiter"
 require "dumbwaiter/mock"
+require "rspec/its"
+require 'rspec/collection_matchers'
 
 Aws.config = {access_key_id: "tacos", secret_access_key: "secret chocolate"}
 I18n.enforce_available_locales = false


### PR DESCRIPTION
We started getting this error in our jenkins deployer script:

```
dumbwaiter-0.5.3/lib/dumbwaiter/stack.rb:14:in `find': undefined method `new' for Aws::OpsWorks:Module (NoMethodError)
```

When we ran the dumbwaiter test suite, it would not run because its and collection matchers were moved out of  rspec. So we added `rspec-its` and `rspec-collection_matchers` to development dependencies.

Once the test suite was running, we changed the call to `Aws::Opsworks.new` to `Aws::Opsworks::Client.new` to keep up with the latest version of `aws-sdk-core`. You can see the central change to the test suite [here](https://github.com/sharespost/dumbwaiter/compare/minifast:master...master#diff-76a1c12e1283c797bf078d390041c9c0R11).
